### PR TITLE
Adding the namespace for geo: WGS84

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -9,6 +9,7 @@
 | rdfs:| `http://www.w3.org/2000/01/rdf-schema#`|
 | foaf:| `http://xmlns.com/foaf/0.1/`|
 | schema:| `http://schema.org/`|
+| geo:| 'http://www.w3.org/2003/01/geo/wgs84_pos#' |
 
 ### [gtfs:Feed](http://vocab.gtfs.org/terms#Feed)
 


### PR DESCRIPTION
Adding the namespace for geo: WGS84 to linked-gtfs spec.md

It is used in the specification but the namespace is not provided.
